### PR TITLE
fix parse_f64 bug

### DIFF
--- a/src/envflag.cpp
+++ b/src/envflag.cpp
@@ -132,6 +132,7 @@ double parse_f64(const char* name, const string_view& value) noexcept {
     for(++s; s < e && isdigit(*s); ++s) {
         double d = *s - '0';
         res += base * d;
+        base *= 0.1;
     }
     FASSERT(s == e)
         (*s)


### PR DESCRIPTION
看起来测试里面只有1.2测试，所以没有触发这个bug（需要小数点后两位开始触发）